### PR TITLE
include app_upstream_response_time when loading ingress into bigquery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ update-db-dump:
 	bq load \
 		--project_id=elife-data-pipeline \
 		--schema="$(CLOUDWATCH_JSONL_SCHEMA_FILE)" \
+		--schema_update_option=ALLOW_FIELD_ADDITION \
 		--source_format=NEWLINE_DELIMITED_JSON \
 		de_proto.sciety_ingress_v1 \
 		"$(CLOUDWATCH_JSONL_FILE)"

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ update-db-dump:
 .upload-ingress-jsonl-to-bigquery:
 	bq load \
 		--project_id=elife-data-pipeline \
+		--noreplace \
 		--schema="$(CLOUDWATCH_JSONL_SCHEMA_FILE)" \
 		--schema_update_option=ALLOW_FIELD_ADDITION \
 		--source_format=NEWLINE_DELIMITED_JSON \

--- a/scripts/convert-cloudwatch-logs-to-bigquery-jsonl.sh
+++ b/scripts/convert-cloudwatch-logs-to-bigquery-jsonl.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 
 cat $1 \
     | sed -e 's/[^ ]* //' \
-    | jq --compact-output 'del(.kubernetes) | del(.docker) | del(.app_upstream_response_time)' \
+    | jq --compact-output 'del(.kubernetes) | del(.docker)' \
     > $1.jsonl


### PR DESCRIPTION
This would now include `app_upstream_response_time` when loading ingress data into BigQuery.
It doesn't do it retrospectively. But we could delete and re-import a certain period (depending for what period this might be interesting).
I have run that for yesterday.

It will import `app_upstream_response_time` as a string. The BigQuery view could then extract from it.
Alternatively we could structure it using `jq`. But it would be inconsistent with `app_upsteam_status` (which may also contain a hyphen).